### PR TITLE
adding maven-surefire-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
 					<compilerArgs>--enable-preview</compilerArgs>
 				</configuration>
 			</plugin>
+			 <plugin>
+				  <groupId>org.apache.maven.plugins</groupId>
+				  <artifactId>maven-surefire-plugin</artifactId>
+				  <configuration>
+						<argLine>--enable-preview</argLine>
+				  </configuration>
+			 </plugin>
 		</plugins>
 	</build>
 	<repositories>


### PR DESCRIPTION
This PR includes configuration of the maven-surefire-plugin to enable Java preview features.