### PR TITLE
adding maven-surefire-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
 					<compilerArgs>--enable-preview</compilerArgs>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>--enable-preview</argLine>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<repositories>

--- a/src/test/java/dev/danvega/danson/post/PostRepositoryTest.java
+++ b/src/test/java/dev/danvega/danson/post/PostRepositoryTest.java
@@ -22,6 +22,14 @@ import static org.junit.jupiter.api.Assertions.*;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class PostRepositoryTest {
 
+    /* Using @ServiceConnection is equal to:
+      @DynamicPropertySource
+      static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+      }
+      so we set application properties to connect to testcontainer db*/
     @Container
     @ServiceConnection
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16.0");


### PR DESCRIPTION
This PR includes configuration of the maven-surefire-plugin to enable Java preview features.